### PR TITLE
Update memory parameter for megahit to be 80% instead of 20%

### DIFF
--- a/workflows/assembly/Snakefile
+++ b/workflows/assembly/Snakefile
@@ -137,7 +137,7 @@ rule assembly_megahit:
         'rm -rf {data_dir}/{params.assembly_megahit_outprefix_wc} '
         '&& '
         'megahit -t {threads} '
-        '--memory 0.20 '
+        '--memory 0.80 '
         '-1 /{input.fwd} '
         '-2 /{input.rev} '
         '--out-prefix={params.assembly_megahit_outprefix_wc} '


### PR DESCRIPTION
#### Merge Checklist

- [ ] Typos are a sign of poorly maintained code. Has this request been checked with a spell checker?
- [ ] Tutorials should be universally reproducible. If this request modifies a tutorial, does it assume we're starting from a blank Ubuntu 16.04 (Xenial Xerus) image?
- [ ] Large diffs to binary or data files can artificially inflate the size of the repository. Are there large diffs to binary or data files, and are these changes necessary?
