### PR TITLE
Fix kaiju links

### DIFF
--- a/workflows/config/default_workflowparams.settings
+++ b/workflows/config/default_workflowparams.settings
@@ -174,7 +174,6 @@ config_default = {
             "dmp2" : "names.dmp",
             "fmi"  : "kaiju_db.fmi",
             "tar"  : "kaiju_index_pg.tgz",
-            #"url"  : "http://kaiju.binf.ku.dk/database",
             "url"  : "https://s3.amazonaws.com/dahak-project-ucdavis/kaiju",
             "out"  : "{sample}.kaiju_output.trim{qual}.out"
         },

--- a/workflows/config/example_workflowparams.json
+++ b/workflows/config/example_workflowparams.json
@@ -118,10 +118,9 @@
         "kaiju" : {
             "dmp1" : "nodes.dmp",
             "dmp2" : "names.dmp",
-            "fmi"  : "kaiju_db_nr.fmi",
-            "tar"  : "kaiju_index_nr.tgz",
-            "url"  : "http://kaiju.binf.ku.dk/database",
-            #"url"  : "https://s3.amazonaws.com/dahak-project-ucdavis/kaiju",
+            "fmi"  : "kaiju_db.fmi",
+            "tar"  : "kaiju_index_pg.tgz",
+            "url"  : "https://s3.amazonaws.com/dahak-project-ucdavis/kaiju",
             "out"  : "{sample}.kaiju_output.trim{qual}.out"
         },
 


### PR DESCRIPTION
This fixes two errant configuration values in the default/example workflow parameter config files:
- which kaiju database/tarball is used (use `_pg`, the `_nr` databases are causing issues)
- URL (use Davis S3 bucket instead of kaiju URL)

#### Merge Checklist

- [x] Typos are a sign of poorly maintained code. Has this request been checked with a spell checker?
- [x] ~Tutorials should be universally reproducible. If this request modifies a tutorial, does it assume we're starting from a blank Ubuntu 16.04 (Xenial Xerus) image?~ n/a
- [x] ~Large diffs to binary or data files can artificially inflate the size of the repository. Are there large diffs to binary or data files, and are these changes necessary?~ n/a
